### PR TITLE
fix: Use strictly greater than sign for transaction limit validation

### DIFF
--- a/src/routes/reservecoin.jsx
+++ b/src/routes/reservecoin.jsx
@@ -94,7 +94,7 @@ export default function ReserveCoin() {
           setBuyValidity(TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED);
         } else if (isWrongChain) {
           setBuyValidity(TRANSACTION_VALIDITY.WRONG_NETWORK);
-        } else if (bcUsdEquivalent >= TRANSACTION_USD_LIMIT) {
+        } else if (bcUsdEquivalent > TRANSACTION_USD_LIMIT) {
           setBuyValidity(TRANSACTION_VALIDITY.TRANSACTION_LIMIT_REACHED);
         } else if (
           stringToBigNumber(accountDetails.unscaledBalanceBc, BC_DECIMALS).lt(
@@ -150,7 +150,7 @@ export default function ReserveCoin() {
           setSellValidity(TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED);
         } else if (isWrongChain) {
           setSellValidity(TRANSACTION_VALIDITY.WRONG_NETWORK);
-        } else if (rcUsdEquivalent >= TRANSACTION_USD_LIMIT) {
+        } else if (rcUsdEquivalent > TRANSACTION_USD_LIMIT) {
           setSellValidity(TRANSACTION_VALIDITY.TRANSACTION_LIMIT_REACHED);
         } else if (
           stringToBigNumber(accountDetails.unscaledBalanceRc, decimals.rcDecimals).lt(

--- a/src/routes/stablecoin.jsx
+++ b/src/routes/stablecoin.jsx
@@ -89,7 +89,7 @@ export default function Stablecoin() {
           setBuyValidity(TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED);
         } else if (isWrongChain) {
           setBuyValidity(TRANSACTION_VALIDITY.WRONG_NETWORK);
-        } else if (amountScaled >= TRANSACTION_USD_LIMIT) {
+        } else if (amountScaled > TRANSACTION_USD_LIMIT) {
           setBuyValidity(TRANSACTION_VALIDITY.TRANSACTION_LIMIT_REACHED);
         } else if (
           stringToBigNumber(accountDetails.unscaledBalanceBc, BC_DECIMALS).lt(
@@ -133,7 +133,7 @@ export default function Stablecoin() {
           setSellValidity(TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED);
         } else if (isWrongChain) {
           setSellValidity(TRANSACTION_VALIDITY.WRONG_NETWORK);
-        } else if (amountScaled >= TRANSACTION_USD_LIMIT) {
+        } else if (amountScaled > TRANSACTION_USD_LIMIT) {
           setSellValidity(TRANSACTION_VALIDITY.TRANSACTION_LIMIT_REACHED);
         } else if (
           stringToBigNumber(accountDetails.unscaledBalanceSc, decimals.scDecimals).lt(


### PR DESCRIPTION
We have an issue related to the transaction limit validation that can be found [here](https://github.com/DjedAlliance/Djed-Solidity-WebDashboard/issues/5).

Changes that should be done:
Use strictly greater than sign ">" instead of greater than or equal "<=".

How to test:
Because of the limit of 10000 USD worth of mADA per transaction,
User should be able to submit the transaction with exact amount of 10000$.