### PR TITLE
fix: Calculating future price when scSupply is zero cause an error

### DIFF
--- a/src/utils/ethereum.js
+++ b/src/utils/ethereum.js
@@ -580,11 +580,11 @@ export const calculateFutureScPrice = async ({
 
     const futureScSupply = BigNumber.from(scSupply).add(BigNumber.from(amountSC));
     const futureRatio = BigNumber.from(ratio).add(BigNumber.from(amountBC));
-    const futurePrice = futureRatio.mul(scDecimalScalingFactor).div(futureScSupply);
 
     if (futureScSupply == 0) {
       return scTargetPrice;
     } else {
+      const futurePrice = futureRatio.mul(scDecimalScalingFactor).div(futureScSupply);
       return BigNumber.from(scTargetPrice).lt(futurePrice)
         ? scTargetPrice
         : futurePrice.toString();


### PR DESCRIPTION
Division by zero causing an error when total supply is zero