### PR TITLE
Update codepreview.yml to not fail on compile warnings

### DIFF
--- a/.github/workflows/codepreview.yml
+++ b/.github/workflows/codepreview.yml
@@ -35,13 +35,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # CI=false disables reporting warnings as errors
       - name: Prepare build (pr)
         if: ${{ (github.head_ref || github.ref_name) != 'main' }}
-        run: npm run build:milkomeda-c1-testnet
+        run: CI=false npm run build:milkomeda-c1-testnet
 
+      # CI=false disables reporting warnings as errors
       - name: Prepare build (main)
         if: ${{ (github.head_ref || github.ref_name) == 'main' }}
-        run: npm run build:milkomeda-c1
+        run: CI=false npm run build:milkomeda-c1
 
       - name: Create SSH key
         run: |


### PR DESCRIPTION
Codepreview workflow from #83 failed because the changes have compile warnings, still, Fleek succeeded, let's disable this behavior so that codepreview workflow continues.