### PR TITLE
removed wallet support other than metamask temporarily

### DIFF
--- a/src/components/molecules/MetamaskStatusButton/WalletConnectButton.jsx
+++ b/src/components/molecules/MetamaskStatusButton/WalletConnectButton.jsx
@@ -46,7 +46,7 @@ const WalletConnectButton = () => {
                 iconWallet={<WalletOutlined />}
                 variant="primary"
               />
-              <CustomButton
+              {/* <CustomButton
                 text={isFlintWalletInstalled ? "Flint Wallet" : "Install Flint"}
                 onClick={isFlintWalletInstalled ? connectFlintWallet : redirectToFlint}
                 iconWallet={<WalletOutlined />}
@@ -75,7 +75,7 @@ const WalletConnectButton = () => {
                 onClick={isNufiWalletInstalled ? connectToNufiWSC : redirectToNufi}
                 iconWallet={<WalletOutlined />}
                 variant="primary"
-              />
+              /> */}
             </>
           )
         }


### PR DESCRIPTION
Current behaviour: when the user clicks on "connect wallet", several wallets appear.

Desired behaviour: when the user clicks on "connect wallet", only Metamask should appear.

The desired behaviour is achieved with the minimum amount of code changes possible because we would like to reactivate all the wallets in the future when the WSC integration work is complete.
