### PR TITLE
Added metadata for social media sharing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,12 @@
     <link rel="icon" href="%PUBLIC_URL%/Logo_symbol.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
+    <meta property="og:title" content="DJED on %REACT_APP_BC%" />
+    <meta name="description" content="Djed is a formally verified crypto-backed autonomous stablecoin protocol. It has been researched since Q2 2020, its whitepaper has been released in August 2021, and it has multiple implementations and deployments. Here you can interact with a deployment that uses these smart contracts on %REACT_APP_BC%." />
+    <meta property="og:description" content="Djed is a formally verified crypto-backed autonomous stablecoin protocol. It has been researched since Q2 2020, its whitepaper has been released in August 2021, and it has multiple implementations and deployments. Here you can interact with a deployment that uses these smart contracts on %REACT_APP_BC%." />
+    <meta property="og:image" content="%PUBLIC_URL%/Logo_symbol.png" />
+    <meta property="og:url" content="%PUBLIC_URL%" />
+    <meta name="twitter:card" content="%PUBLIC_URL%/Logo_symbol.png" />
     <!--link rel="apple-touch-icon" href="%PUBLIC_URL%/logo180.png" /-->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
Fixes #103 

I looks something like
<img width="549" alt="image" src="https://github.com/DjedAlliance/Djed-Solidity-WebDashboard/assets/96711588/896c2c71-9206-471c-9ee1-40fa57034c1e">

It shows `%REACT_APP_BC%` because deployment is not done using .env file in pr, it fetches data from .env file in production.

`%REACT_APP_BC%` gets replaced by `Milkomeda` or `Sepolia` whatever is present in .env file.