### PR TITLE
Implement tab activity detection to optimize  API calls

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -37,7 +37,7 @@ module.exports = {
             warning.details &&
             warning.details.includes("source-map-loader")
           );
-        },
+        }
       ];
 
       return webpackConfig;

--- a/src/context/AppProvider.jsx
+++ b/src/context/AppProvider.jsx
@@ -55,6 +55,19 @@ export const AppProvider = ({ children }) => {
   const [systemParams, setSystemParams] = useState(null);
   const [accountDetails, setAccountDetails] = useState(null);
   const [coinBudgets, setCoinBudgets] = useState(null);
+  const [isVisible, setIsVisible] = useState(document.visibilityState === "visible");
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setIsVisible(document.visibilityState === "visible");
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
   useEffect(() => {
     if (!account) return;
     const setUp = async () => {
@@ -188,7 +201,7 @@ export const AppProvider = ({ children }) => {
 
   useInterval(
     async () => {
-      if (coinContracts == null) return;
+      if (coinContracts == null || !isVisible) return;
       const accountDetails = await getAccountDetails(
         web3,
         account,
@@ -206,12 +219,12 @@ export const AppProvider = ({ children }) => {
       );
       setCoinBudgets(coinBudgets);
     },
-    isWalletConnected ? ACCOUNT_DETAILS_REQUEST_INTERVAL : null
+    isWalletConnected && isVisible ? ACCOUNT_DETAILS_REQUEST_INTERVAL : null
   );
 
   useInterval(
     async () => {
-      if (coinContracts == null) return;
+      if (coinContracts == null || !isVisible) return;
       const coinsDetails = await getCoinDetails(
         coinContracts.stableCoin,
         coinContracts.reserveCoin,
@@ -222,7 +235,7 @@ export const AppProvider = ({ children }) => {
       );
       setCoinsDetails(coinsDetails);
     },
-    isWalletConnected ? COIN_DETAILS_REQUEST_INTERVAL : null
+    isWalletConnected && isVisible ? COIN_DETAILS_REQUEST_INTERVAL : null
   );
 
   const isRatioBelowMax = ({ scPrice, reserveBc }) => {

--- a/src/routes/reservecoin.jsx
+++ b/src/routes/reservecoin.jsx
@@ -291,7 +291,11 @@ export default function ReserveCoin() {
     ? buyValidity === TRANSACTION_VALIDITY.OK
     : sellValidity === TRANSACTION_VALIDITY.OK;
 
-  const buttonDisabled = isNaN(parseInt(value)) || parseInt(value) === 0 || isWrongChain || !transactionValidated;
+  const buttonDisabled =
+    isNaN(parseInt(value)) ||
+    parseInt(value) === 0 ||
+    isWrongChain ||
+    !transactionValidated;
 
   const rcFloat = parseFloat(coinsDetails?.scaledNumberRc.replaceAll(",", ""));
   const rcConverted = getRcUsdEquivalent(coinsDetails, rcFloat);

--- a/src/routes/stablecoin.jsx
+++ b/src/routes/stablecoin.jsx
@@ -266,7 +266,11 @@ export default function Stablecoin() {
     ? buyValidity === TRANSACTION_VALIDITY.OK
     : sellValidity === TRANSACTION_VALIDITY.OK;
 
-  const buttonDisabled = isNaN(parseInt(value)) || parseInt(value) === 0 || isWrongChain || !transactionValidated;
+  const buttonDisabled =
+    isNaN(parseInt(value)) ||
+    parseInt(value) === 0 ||
+    isWrongChain ||
+    !transactionValidated;
 
   const scFloat = parseFloat(coinsDetails?.scaledNumberSc.replaceAll(",", ""));
   const scConverted = getScAdaEquivalent(coinsDetails, scFloat);


### PR DESCRIPTION
### **Overview:**
This resolves #105 
Previously, the application was fetching the price at regular intervals, regardless of whether the user's tab was active or not. This approach led to reaching the daily limit of the free Infura API when deployed for Sepolia, as a single user could leave a tab open, consuming the limit.

Implemented a solution that detects whether the tab is active or not. The price update logic now only executes when the tab is active, significantly reducing the number of API calls and preventing the daily limit from being reached.

This change ensures that the application remains functional and efficient under the constraints of the free Infura API, while also improving the user experience by reducing unnecessary data fetching when the application is not in use.

###  Detailed Description:

| Before Changes | After Changes |
|:---:|:---:|
| ![before changes](https://github.com/DjedAlliance/Djed-Solidity-WebDashboard/assets/157852043/22baf38c-a0d7-4477-9169-c0abd05a22b1) | ![after changes](https://github.com/DjedAlliance/Djed-Solidity-WebDashboard/assets/157852043/317f029a-93c7-4f09-8f1b-5e5e224a1fe6) |

As shown in the images ,Previously, even when the tab was not active and the user had switched to another tab, there were **10 request methods** being called every minute. This behaviour could easily lead to exceeding the API rate limit.

implementing a solution that involves detecting whether the tab is active. As a result,  **no requests (zero)** are being made when the tab is not active.

