### PR TITLE
making changes to accept float values while buying/selling coins

### DIFF
--- a/src/routes/reservecoin.jsx
+++ b/src/routes/reservecoin.jsx
@@ -292,8 +292,8 @@ export default function ReserveCoin() {
     : sellValidity === TRANSACTION_VALIDITY.OK;
 
   const buttonDisabled =
-    isNaN(parseInt(value)) ||
-    parseInt(value) === 0 ||
+    isNaN(parseFloat(value)) ||
+    parseFloat(value) === 0 ||
     isWrongChain ||
     !transactionValidated;
 

--- a/src/routes/stablecoin.jsx
+++ b/src/routes/stablecoin.jsx
@@ -267,8 +267,8 @@ export default function Stablecoin() {
     : sellValidity === TRANSACTION_VALIDITY.OK;
 
   const buttonDisabled =
-    isNaN(parseInt(value)) ||
-    parseInt(value) === 0 ||
+    isNaN(parseFloat(value)) ||
+    parseFloat(value) === 0 ||
     isWrongChain ||
     !transactionValidated;
 


### PR DESCRIPTION
When we input a float value suppose say 0.01,the parseInt value is set to true(because it cannot handle float values,it truncates the digits after decimal points and returns 0) and the button is disabled even when the transaction is valid.
#117 