### PR TITLE
Refactor: Extract shared logic from stablecoin.jsx and reservecoin.jsx to remove duplication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,9 @@
         "web3": "^1.7.3"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@craco/craco": "^7.1.0",
+        "@playwright/test": "^1.35.1",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
@@ -722,9 +724,18 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1975,6 +1986,18 @@
         "babel-plugin-polyfill-regenerator": "^0.5.1",
         "core-js-compat": "^3.31.0"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       },
@@ -4474,6 +4497,22 @@
       },
       "peerDependencies": {
         "algosdk": "^2.1.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -18042,6 +18081,38 @@
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build:mordor": "npx -y env-cmd -f ./env/mordor.env npm run build",
     "build:ethereum-classic": "npx -y env-cmd -f ./env/ethereum-classic.env npm run build",
     "test": "craco test",
+    "test:e2e": "playwright test",
     "lint": "prettier --check '**/*.{js,jsx}'",
     "format": "prettier --write '**/*.{js,jsx}'",
     "eject": "react-scripts eject"
@@ -55,7 +56,9 @@
     "@testing-library/user-event": "^13.5.0",
     "eslint-plugin-react-hooks": "^4.5.0",
     "prettier": "^2.6.2",
-    "sass": "^1.49.9"
+    "sass": "^1.49.9",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@playwright/test": "^1.35.1"
   },
   "resolutions": {
     "ethers": "^5.7.2"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,18 @@
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  timeout: 30 * 1000,
+  testDir: 'tests/playwright',
+  retries: 0,
+  use: {
+    headless: true,
+    baseURL: 'http://localhost:3000'
+  },
+  webServer: {
+    command: 'npm start',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: false
+  }
+};
+
+module.exports = config;

--- a/src/routes/CoinWSCButton.jsx
+++ b/src/routes/CoinWSCButton.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { useAccount } from "wagmi";
+import { ethers } from "ethers";
+import djedArtifact from "../artifacts/Djed.json";
+import { DJED_ADDRESS, FEE_UI_UNSCALED, UI } from "../utils/ethereum";
+import { ConnectWSCButton, TransactionConfigWSCProvider } from "milkomeda-wsc-ui-test-beta";
+
+const WSCButton = ({
+  disabled,
+  currentAmount,
+  unwrapAmount,
+  stepTxDirection,
+  evmTokenAddress,
+  cardanoWrapTokenUnit,
+  buyFunctionName,
+  sellFunctionName,
+  titleBuy,
+  titleSell
+}) => {
+  const { address: account } = useAccount();
+
+  const buyOptions = {
+    defaultWrapToken: {
+      unit: "lovelace",
+      amount: currentAmount // amountUnscaled
+    },
+    defaultUnwrapToken: {
+      unit: evmTokenAddress,
+      amount: unwrapAmount // amountUnscaled
+    },
+    titleModal: titleBuy,
+    evmTokenAddress,
+    evmContractRequest: {
+      address: DJED_ADDRESS,
+      abi: djedArtifact.abi,
+      functionName: buyFunctionName,
+      args: [account, FEE_UI_UNSCALED, UI],
+      overrides: {
+        value: ethers.BigNumber.from(currentAmount ?? "0")
+      }
+    }
+  };
+
+  const sellOptions = {
+    defaultWrapToken: {
+      unit: cardanoWrapTokenUnit,
+      amount: currentAmount
+    },
+    defaultUnwrapToken: {
+      unit: "",
+      amount: unwrapAmount // totalBCUnscaled
+    },
+    titleModal: titleSell,
+    evmTokenAddress,
+    evmContractRequest: {
+      address: DJED_ADDRESS,
+      abi: djedArtifact.abi,
+      functionName: sellFunctionName,
+      args: [currentAmount, account, FEE_UI_UNSCALED, UI],
+      overrides: {
+        value: ethers.BigNumber.from("0")
+      }
+    }
+  };
+
+  return (
+    <TransactionConfigWSCProvider options={stepTxDirection === "buy" ? buyOptions : sellOptions}>
+      <ConnectWSCButton disabled={disabled} />
+    </TransactionConfigWSCProvider>
+  );
+};
+
+export default WSCButton;

--- a/src/routes/coinTradeHelpers.js
+++ b/src/routes/coinTradeHelpers.js
@@ -1,0 +1,156 @@
+import { TRANSACTION_VALIDITY } from "../utils/constants";
+import { BigNumber } from "ethers";
+
+export function createBuyHandler(options) {
+  const {
+    validatePositiveNumber,
+    tradeDataPriceBuy,
+    djedContract,
+    decimalsValue,
+    getFutureScPrice,
+    calculateTxFees,
+    systemParams,
+    isWalletConnected,
+    isWrongChain,
+    coinsDetails,
+    accountDetails,
+    isTxLimitReached,
+    checkBuyable,
+    stringToBigNumber,
+    BC_DECIMALS,
+    setTradeData,
+    setBuyValidity,
+    amountForLimitFn,
+    isRatioOkFn
+  } = options;
+
+  return (amountScaled) => {
+    const inputSanity = validatePositiveNumber(amountScaled);
+    if (inputSanity !== TRANSACTION_VALIDITY.OK) {
+      setBuyValidity(inputSanity);
+      return;
+    }
+    const getTradeData = async () => {
+      try {
+        const data = await tradeDataPriceBuy(djedContract, decimalsValue, amountScaled);
+        const futureSCPrice = await getFutureScPrice({
+          amountBC: data.totalUnscaled,
+          amountSC: data.amountUnscaled
+        });
+        const { f } = calculateTxFees(data.totalUnscaled, systemParams?.feeUnscaled, 0);
+
+        const isRatioOk = isRatioOkFn({
+          totalScSupply: BigNumber.from(coinsDetails?.unscaledNumberSc).add(
+            BigNumber.from(data.amountUnscaled)
+          ),
+          scPrice: BigNumber.from(futureSCPrice),
+          reserveBc: BigNumber.from(coinsDetails?.unscaledReserveBc).add(
+            BigNumber.from(data.totalUnscaled).add(f)
+          )
+        });
+
+        setTradeData(data);
+        if (!isWalletConnected) {
+          setBuyValidity(TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED);
+        } else if (isWrongChain) {
+          setBuyValidity(TRANSACTION_VALIDITY.WRONG_NETWORK);
+        } else if (
+          isTxLimitReached(amountForLimitFn(amountScaled, data), coinsDetails.unscaledNumberSc, systemParams.thresholdSupplySC)
+        ) {
+          setBuyValidity(TRANSACTION_VALIDITY.TRANSACTION_LIMIT_REACHED);
+        } else if (
+          stringToBigNumber(accountDetails.unscaledBalanceBc, BC_DECIMALS).lt(
+            stringToBigNumber(data.totalBCUnscaled, BC_DECIMALS)
+          )
+        ) {
+          setBuyValidity(TRANSACTION_VALIDITY.INSUFFICIENT_BC);
+        } else if (!isRatioOk) {
+          setBuyValidity(options.ratioFailState || TRANSACTION_VALIDITY.RESERVE_RATIO_LOW);
+        } else {
+          checkBuyable(djedContract, data.amountUnscaled, options.budgetUnscaled).then((res) => {
+            setBuyValidity(res);
+          });
+        }
+      } catch (error) {
+        console.log("error", error);
+      }
+    };
+    getTradeData();
+  };
+}
+
+export function createSellHandler(options) {
+  const {
+    validatePositiveNumber,
+    tradeDataPriceSell,
+    djedContract,
+    decimalsValue,
+    getFutureScPrice,
+    calculateTxFees,
+    systemParams,
+    isWalletConnected,
+    isWrongChain,
+    coinsDetails,
+    accountDetails,
+    isTxLimitReached,
+    checkSellable,
+    stringToBigNumber,
+    bcDecimals,
+    setTradeData,
+    setSellValidity,
+    amountForLimitFn,
+    isRatioOkFn
+  } = options;
+
+  return (amountScaled) => {
+    const inputSanity = validatePositiveNumber(amountScaled);
+    if (inputSanity !== TRANSACTION_VALIDITY.OK) {
+      setSellValidity(inputSanity);
+      return;
+    }
+    const getTradeData = async () => {
+      try {
+        const data = await tradeDataPriceSell(djedContract, decimalsValue, amountScaled);
+        const futureSCPrice = await getFutureScPrice({
+          amountBC: data.totalUnscaled,
+          amountSC: 0
+        });
+        const { f } = calculateTxFees(data.totalUnscaled, systemParams?.feeUnscaled, 0);
+
+        const isRatioOk = isRatioOkFn({
+          totalScSupply: BigNumber.from(coinsDetails?.unscaledNumberSc),
+          scPrice: BigNumber.from(futureSCPrice),
+          reserveBc: BigNumber.from(coinsDetails?.unscaledReserveBc).sub(
+            BigNumber.from(data.totalUnscaled).sub(f)
+          )
+        });
+
+        setTradeData(data);
+        if (!isWalletConnected) {
+          setSellValidity(TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED);
+        } else if (isWrongChain) {
+          setSellValidity(TRANSACTION_VALIDITY.WRONG_NETWORK);
+        } else if (
+          isTxLimitReached(amountForLimitFn(amountScaled, data), coinsDetails.unscaledNumberSc, systemParams.thresholdSupplySC)
+        ) {
+          setSellValidity(TRANSACTION_VALIDITY.TRANSACTION_LIMIT_REACHED);
+        } else if (
+          stringToBigNumber(accountDetails.unscaledBalanceSc, bcDecimals).lt(
+            stringToBigNumber(data.amountUnscaled, bcDecimals)
+          )
+        ) {
+          setSellValidity(TRANSACTION_VALIDITY.INSUFFICIENT_SC);
+        } else if (!isRatioOk) {
+          setSellValidity(options.ratioFailState || TRANSACTION_VALIDITY.RESERVE_RATIO_LOW);
+        } else {
+          checkSellable(data.amountUnscaled, accountDetails?.unscaledBalanceSc).then((res) =>
+            setSellValidity(res)
+          );
+        }
+      } catch (error) {
+        console.log("error", error);
+      }
+    };
+    getTradeData();
+  };
+}

--- a/src/routes/reservecoin.jsx
+++ b/src/routes/reservecoin.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import MetamaskConnectButton from "../components/molecules/MetamaskConnectButton/MetamaskConnectButton";
 import CoinCard from "../components/molecules/CoinCard/CoinCard";
 import OperationSelector from "../components/organisms/OperationSelector/OperationSelector";
@@ -8,40 +8,24 @@ import BuySellButton from "../components/molecules/BuySellButton/BuySellButton";
 
 import "./_CoinSection.scss";
 import { useAppProvider } from "../context/AppProvider";
-import useBuyOrSell from "../utils/hooks/useBuyOrSell";
 import { TRANSACTION_VALIDITY } from "../utils/constants";
 import {
   calculateBcUsdEquivalent,
   calculateRcUsdEquivalent,
-  getRcUsdEquivalent,
-  stringToBigNumber,
-  validatePositiveNumber
+  getRcUsdEquivalent
 } from "../utils/helpers";
 import {
   buyRcTx,
-  promiseTx,
   sellRcTx,
   tradeDataPriceBuyRc,
   tradeDataPriceSellRc,
   checkBuyableRc,
   checkSellableRc,
-  verifyTx,
-  BC_DECIMALS,
-  calculateTxFees,
-  isTxLimitReached,
-  DJED_ADDRESS,
-  FEE_UI_UNSCALED,
-  UI
+  BC_DECIMALS
 } from "../utils/ethereum";
-import { BigNumber, ethers } from "ethers";
-import {
-  ConnectWSCButton,
-  TransactionConfigWSCProvider,
-  useWSCProvider,
-  useModal as useWSCModal
-} from "milkomeda-wsc-ui-test-beta";
-import djedArtifact from "../artifacts/Djed.json";
-import { useAccount } from "wagmi";
+// isWSCConnected is returned by useCoinTrade
+import useCoinTrade from "./useCoinTrade";
+import WSCButton from "./CoinWSCButton";
 
 export default function ReserveCoin() {
   const {
@@ -61,241 +45,69 @@ export default function ReserveCoin() {
     coinContracts,
     getFutureScPrice
   } = useAppProvider();
-  const { isWSCConnected } = useWSCProvider();
-  const { setOpen } = useWSCModal();
-  const { buyOrSell, isBuyActive, setBuyOrSell } = useBuyOrSell();
-  const [tradeData, setTradeData] = useState({});
-  const [value, setValue] = useState(null);
-  const [termsAccepted, setTermsAccepted] = useState(false);
-  const [txError, setTxError] = useState(null);
-  const [txStatus, setTxStatus] = useState("idle");
-  const [buyValidity, setBuyValidity] = useState(
-    TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED
-  );
-  const [sellValidity, setSellValidity] = useState(
-    TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED
-  );
+  // isWSCConnected comes from the useCoinTrade hook
 
-  const txStatusPending = txStatus === "pending";
-  const txStatusRejected = txStatus === "rejected";
-  const txStatusSuccess = txStatus === "success";
-
-  const updateBuyTradeData = (amountScaled) => {
-    const inputSanity = validatePositiveNumber(amountScaled);
-    if (inputSanity !== TRANSACTION_VALIDITY.OK) {
-      setBuyValidity(inputSanity);
-      return;
+  const {
+    tradeData,
+    value,
+    termsAccepted,
+    txError,
+    txStatus,
+    buyValidity,
+    sellValidity,
+    txStatusPending,
+    txStatusRejected,
+    txStatusSuccess,
+    buyFunction,
+    sellFunction,
+    tradeFxn,
+    currentAmount,
+    onChangeBuyInput,
+    onChangeSellInput,
+    onSubmit,
+    transactionValidated,
+    buttonDisabled,
+    setValue,
+    setTermsAccepted,
+    setBuyOrSell,
+    setBuyValidity,
+    setSellValidity,
+    isBuyActive,
+    isWSCConnected
+  } = useCoinTrade({
+    createBuyOptions: {
+      tradeDataPriceBuy: tradeDataPriceBuyRc,
+      decimalsValue: decimals.rcDecimals,
+      checkBuyable: checkBuyableRc,
+      bcDecimals: BC_DECIMALS,
+      amountForLimitFn: (amountScaled, data) =>
+        calculateBcUsdEquivalent(coinsDetails, parseFloat(data.totalScaled.replaceAll(",", ""))).replaceAll(",", ""),
+      isRatioOkFn: ({ totalScSupply, scPrice, reserveBc }) => isRatioBelowMax({ scPrice, reserveBc }),
+      ratioFailState: TRANSACTION_VALIDITY.RESERVE_RATIO_HIGH,
+      budgetUnscaled: coinBudgets?.unscaledBudgetRc,
+      buyTx: buyRcTx
+    },
+    createSellOptions: {
+      tradeDataPriceSell: tradeDataPriceSellRc,
+      decimalsValue: decimals.rcDecimals,
+      checkSellable: checkSellableRc,
+      bcDecimals: decimals.rcDecimals,
+      amountForLimitFn: (amountScaled, data) =>
+        calculateRcUsdEquivalent(coinsDetails, parseFloat(data.amountScaled.replaceAll(",", ""))).replaceAll(",", ""),
+      isRatioOkFn: ({ totalScSupply, scPrice, reserveBc }) => isRatioAboveMin({ totalScSupply, scPrice, reserveBc }),
+      ratioFailState: TRANSACTION_VALIDITY.RESERVE_RATIO_LOW,
+      sellTx: sellRcTx
     }
-    const getTradeData = async () => {
-      try {
-        const data = await tradeDataPriceBuyRc(
-          djedContract,
-          decimals.rcDecimals,
-          amountScaled
-        );
-        const futureSCPrice = await getFutureScPrice({
-          amountBC: data.totalUnscaled,
-          amountSC: 0
-        });
+  });
 
-        const { f } = calculateTxFees(data.totalUnscaled, systemParams?.feeUnscaled, 0);
-        const isRatioBelowMaximum = isRatioBelowMax({
-          scPrice: BigNumber.from(futureSCPrice),
-          reserveBc: BigNumber.from(coinsDetails?.unscaledReserveBc).add(
-            BigNumber.from(data.totalUnscaled).add(f)
-          )
-        });
-        const bcUsdEquivalent = calculateBcUsdEquivalent(
-          coinsDetails,
-          parseFloat(data.totalScaled.replaceAll(",", ""))
-        ).replaceAll(",", "");
 
-        setTradeData(data);
-        if (!isWalletConnected) {
-          setBuyValidity(TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED);
-        } else if (isWrongChain) {
-          setBuyValidity(TRANSACTION_VALIDITY.WRONG_NETWORK);
-        } else if (
-          isTxLimitReached(
-            bcUsdEquivalent,
-            coinsDetails.unscaledNumberSc,
-            systemParams.thresholdSupplySC
-          )
-        ) {
-          setBuyValidity(TRANSACTION_VALIDITY.TRANSACTION_LIMIT_REACHED);
-        } else if (
-          stringToBigNumber(accountDetails.unscaledBalanceBc, BC_DECIMALS).lt(
-            stringToBigNumber(data.totalBCUnscaled, BC_DECIMALS)
-          )
-        ) {
-          setBuyValidity(TRANSACTION_VALIDITY.INSUFFICIENT_BC);
-        } else if (!isRatioBelowMaximum) {
-          setBuyValidity(TRANSACTION_VALIDITY.RESERVE_RATIO_HIGH);
-        } else {
-          checkBuyableRc(
-            djedContract,
-            data.amountUnscaled,
-            coinBudgets?.unscaledBudgetRc
-          ).then((res) => setBuyValidity(res));
-        }
-      } catch (error) {
-        console.log("error", error);
-      }
-    };
-    getTradeData();
-  };
 
-  const updateSellTradeData = (amountScaled) => {
-    const inputSanity = validatePositiveNumber(amountScaled);
-    if (inputSanity !== TRANSACTION_VALIDITY.OK) {
-      setSellValidity(inputSanity);
-      return;
-    }
-    const getTradeData = async () => {
-      try {
-        const data = await tradeDataPriceSellRc(
-          djedContract,
-          decimals.rcDecimals,
-          amountScaled
-        );
-        const rcUsdEquivalent = calculateRcUsdEquivalent(
-          coinsDetails,
-          parseFloat(data.amountScaled.replaceAll(",", ""))
-        ).replaceAll(",", "");
-        const futureSCPrice = await getFutureScPrice({
-          amountBC: data.totalUnscaled,
-          amountSC: 0
-        });
-        const { f } = calculateTxFees(data.totalUnscaled, systemParams?.feeUnscaled, 0);
-        const isRatioAboveMinimum = isRatioAboveMin({
-          totalScSupply: BigNumber.from(coinsDetails?.unscaledNumberSc),
-          scPrice: BigNumber.from(futureSCPrice),
-          reserveBc: BigNumber.from(coinsDetails?.unscaledReserveBc).sub(
-            BigNumber.from(data.totalUnscaled).sub(f)
-          )
-        });
 
-        setTradeData(data);
-        if (!isWalletConnected) {
-          setSellValidity(TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED);
-        } else if (isWrongChain) {
-          setSellValidity(TRANSACTION_VALIDITY.WRONG_NETWORK);
-        } else if (
-          isTxLimitReached(
-            rcUsdEquivalent,
-            coinsDetails.unscaledNumberSc,
-            systemParams.thresholdSupplySC
-          )
-        ) {
-          setSellValidity(TRANSACTION_VALIDITY.TRANSACTION_LIMIT_REACHED);
-        } else if (
-          stringToBigNumber(accountDetails.unscaledBalanceRc, decimals.rcDecimals).lt(
-            stringToBigNumber(data.amountUnscaled, decimals.rcDecimals)
-          )
-        ) {
-          setSellValidity(TRANSACTION_VALIDITY.INSUFFICIENT_RC);
-        } else if (!isRatioAboveMinimum) {
-          setSellValidity(TRANSACTION_VALIDITY.RESERVE_RATIO_LOW);
-        } else {
-          checkSellableRc(
-            djedContract,
-            data.amountUnscaled,
-            accountDetails?.unscaledBalanceRc
-          ).then((res) => setSellValidity(res));
-        }
-      } catch (error) {
-        console.log("error", error);
-      }
-    };
-    getTradeData();
-  };
 
-  const onChangeBuyInput = (amountScaled) => {
-    setValue(amountScaled);
-    updateBuyTradeData(amountScaled);
-  };
 
-  const onChangeSellInput = (amountScaled) => {
-    setValue(amountScaled);
-    updateSellTradeData(amountScaled);
-  };
 
-  const buyRc = (total) => {
-    console.log("Attempting to buy RC for", total);
-    setTxStatus("pending");
-    // TODO: pass to buyRcTx a parameter to enforce gasLimit if we are using WSC
-    promiseTx(isWalletConnected, buyRcTx(djedContract, account, total), signer)
-      .then(({ hash }) => {
-        verifyTx(web3, hash).then((res) => {
-          if (res) {
-            console.log("Buy RC success!");
-            setTxStatus("success");
-          } else {
-            console.log("Buy RC reverted!");
-            setTxError("The transaction reverted.");
-            setTxStatus("rejected");
-          }
-        });
-      })
-      .catch((err) => {
-        console.error("Error:", err.message);
-        setTxStatus("rejected");
-        setTxError("MetaMask error. See developer console for details.");
-      });
-  };
 
-  const sellRc = (amount) => {
-    console.log("Attempting to sell RC in amount", amount);
-    setTxStatus("pending");
-    promiseTx(isWalletConnected, sellRcTx(djedContract, account, amount), signer)
-      .then(({ hash }) => {
-        verifyTx(web3, hash).then((res) => {
-          console.log(hash, "hash");
-          if (res) {
-            console.log("Sell RC success!", hash);
-            setTxStatus("success");
-          } else {
-            console.log("Sell RC reverted!");
-            setTxError("The transaction reverted.");
-            setTxStatus("rejected");
-          }
-        });
-      })
-      .catch((err) => {
-        console.error("Error:", err.message);
-        setTxStatus("rejected");
-        setTxError("MetaMask error. See developer console for details.");
-      });
-  };
 
-  const tradeFxn = isBuyActive
-    ? buyRc.bind(null, tradeData.totalBCUnscaled)
-    : sellRc.bind(null, tradeData.amountUnscaled);
-
-  const currentAmount = isBuyActive
-    ? tradeData.totalBCUnscaled
-    : tradeData.amountUnscaled;
-
-  const onSubmit = (e) => {
-    if (!isWalletConnected) return;
-    if (!termsAccepted) return;
-    e.preventDefault();
-    if (isWSCConnected) {
-      setOpen(true);
-      return;
-    }
-    tradeFxn();
-  };
-
-  const transactionValidated = isBuyActive
-    ? buyValidity === TRANSACTION_VALIDITY.OK
-    : sellValidity === TRANSACTION_VALIDITY.OK;
-
-  const buttonDisabled =
-    isNaN(parseFloat(value)) ||
-    parseFloat(value) === 0 ||
-    isWrongChain ||
-    !transactionValidated;
 
   const rcFloat = parseFloat(coinsDetails?.scaledNumberRc.replaceAll(",", ""));
   const rcConverted = getRcUsdEquivalent(coinsDetails, rcFloat);
@@ -423,6 +235,12 @@ export default function ReserveCoin() {
                       unwrapAmount={
                         isBuyActive ? tradeData.amountUnscaled : tradeData.totalBCUnscaled
                       }
+                      evmTokenAddress={process.env.REACT_APP_EVM_RESERVECOIN_ADDRESS}
+                      cardanoWrapTokenUnit={process.env.REACT_APP_CARDANO_RESERVECOIN_ADDRESS}
+                      buyFunctionName="buyReserveCoins"
+                      sellFunctionName="sellReserveCoins"
+                      titleBuy="Buy RC with WSC"
+                      titleSell="Sell RC with WSC"
                     />
                   ) : (
                     <BuySellButton
@@ -472,58 +290,4 @@ export default function ReserveCoin() {
   );
 }
 
-const WSCButton = ({ disabled, currentAmount, unwrapAmount, stepTxDirection }) => {
-  const { address: account } = useAccount();
-
-  const buyOptions = {
-    defaultWrapToken: {
-      unit: "lovelace",
-      amount: currentAmount
-    },
-    defaultUnwrapToken: {
-      unit: process.env.REACT_APP_EVM_RESERVECOIN_ADDRESS,
-      amount: unwrapAmount // amountUnscaled
-    },
-    titleModal: "Buy RC with WSC",
-    evmTokenAddress: process.env.REACT_APP_EVM_RESERVECOIN_ADDRESS,
-    evmContractRequest: {
-      address: DJED_ADDRESS,
-      abi: djedArtifact.abi,
-      functionName: "buyReserveCoins", //account, FEE_UI_UNSCALED, UI
-      args: [account, FEE_UI_UNSCALED, UI],
-      overrides: {
-        value: ethers.BigNumber.from(currentAmount ?? "0")
-      }
-    }
-  };
-
-  const sellOptions = {
-    defaultWrapToken: {
-      unit: process.env.REACT_APP_CARDANO_RESERVECOIN_ADDRESS,
-      amount: currentAmount
-    },
-    defaultUnwrapToken: {
-      unit: "",
-      amount: unwrapAmount // totalBCUnscaled
-    },
-    titleModal: "Sell RC with WSC",
-    evmTokenAddress: process.env.REACT_APP_EVM_RESERVECOIN_ADDRESS,
-    evmContractRequest: {
-      address: DJED_ADDRESS,
-      abi: djedArtifact.abi,
-      functionName: "sellReserveCoins", //amount, account, FEE_UI_UNSCALED, UI
-      args: [currentAmount, account, FEE_UI_UNSCALED, UI],
-      overrides: {
-        value: "0"
-      }
-    }
-  };
-
-  return (
-    <TransactionConfigWSCProvider
-      options={stepTxDirection === "buy" ? buyOptions : sellOptions}
-    >
-      <ConnectWSCButton disabled={disabled} />
-    </TransactionConfigWSCProvider>
-  );
-};
+// WSC button is now provided by src/routes/CoinWSCButton

--- a/src/routes/stablecoin.jsx
+++ b/src/routes/stablecoin.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import MetamaskConnectButton from "../components/molecules/MetamaskConnectButton/MetamaskConnectButton";
 import CoinCard from "../components/molecules/CoinCard/CoinCard";
 import OperationSelector from "../components/organisms/OperationSelector/OperationSelector";
@@ -8,38 +8,20 @@ import BuySellButton from "../components/molecules/BuySellButton/BuySellButton";
 
 import "./_CoinSection.scss";
 import { useAppProvider } from "../context/AppProvider";
-import useBuyOrSell from "../utils/hooks/useBuyOrSell";
 import { TRANSACTION_VALIDITY } from "../utils/constants";
-import {
-  getScAdaEquivalent,
-  stringToBigNumber,
-  validatePositiveNumber
-} from "../utils/helpers";
+import { getScAdaEquivalent } from "../utils/helpers";
 import {
   buyScTx,
-  promiseTx,
   sellScTx,
   tradeDataPriceBuySc,
   tradeDataPriceSellSc,
   checkBuyableSc,
   checkSellableSc,
-  verifyTx,
-  BC_DECIMALS,
-  calculateTxFees,
-  isTxLimitReached,
-  DJED_ADDRESS,
-  FEE_UI_UNSCALED,
-  UI
+  BC_DECIMALS
 } from "../utils/ethereum";
-import { BigNumber, ethers } from "ethers";
-import { useAccount } from "wagmi";
-import djedArtifact from "../artifacts/Djed.json";
-import {
-  ConnectWSCButton,
-  TransactionConfigWSCProvider,
-  useModal as useWSCModal,
-  useWSCProvider
-} from "milkomeda-wsc-ui-test-beta";
+import WSCButton from "./CoinWSCButton";
+import { useWSCProvider } from "milkomeda-wsc-ui-test-beta";
+import useCoinTrade from "./useCoinTrade";
 
 export default function Stablecoin() {
   const {
@@ -58,219 +40,57 @@ export default function Stablecoin() {
     coinContracts,
     getFutureScPrice
   } = useAppProvider();
-  const { isWSCConnected } = useWSCProvider();
-  const { setOpen } = useWSCModal();
 
-  const { buyOrSell, isBuyActive, setBuyOrSell } = useBuyOrSell();
-  const [tradeData, setTradeData] = useState({});
-  const [value, setValue] = useState(null);
-  const [termsAccepted, setTermsAccepted] = useState(false);
-  const [txError, setTxError] = useState(null);
-  const [txStatus, setTxStatus] = useState("idle");
-  const [buyValidity, setBuyValidity] = useState(
-    TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED
-  );
-  const [sellValidity, setSellValidity] = useState(
-    TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED
-  );
-
-  const txStatusPending = txStatus === "pending";
-  const txStatusRejected = txStatus === "rejected";
-  const txStatusSuccess = txStatus === "success";
-
-  const updateBuyTradeData = (amountScaled) => {
-    const inputSanity = validatePositiveNumber(amountScaled);
-    if (inputSanity !== TRANSACTION_VALIDITY.OK) {
-      setBuyValidity(inputSanity);
-      return;
+  const {
+    tradeData,
+    value,
+    termsAccepted,
+    txError,
+    txStatus,
+    buyValidity,
+    sellValidity,
+    txStatusPending,
+    txStatusRejected,
+    txStatusSuccess,
+    buyFunction,
+    sellFunction,
+    tradeFxn,
+    currentAmount,
+    onChangeBuyInput,
+    onChangeSellInput,
+    onSubmit,
+    transactionValidated,
+    buttonDisabled,
+    setValue,
+    setTermsAccepted,
+    setBuyOrSell,
+    setBuyValidity,
+    setSellValidity,
+    isBuyActive,
+    isWSCConnected
+  } = useCoinTrade({
+    createBuyOptions: {
+      tradeDataPriceBuy: tradeDataPriceBuySc,
+      decimalsValue: decimals.scDecimals,
+      checkBuyable: checkBuyableSc,
+      bcDecimals: BC_DECIMALS,
+      amountForLimitFn: (amountScaled) => amountScaled,
+      isRatioOkFn: ({ totalScSupply, scPrice, reserveBc }) =>
+        isRatioAboveMin({ totalScSupply, scPrice, reserveBc }),
+      budgetUnscaled: coinBudgets?.unscaledBudgetSc,
+      buyTx: buyScTx
+    },
+    createSellOptions: {
+      tradeDataPriceSell: tradeDataPriceSellSc,
+      decimalsValue: decimals.scDecimals,
+      checkSellable: checkSellableSc,
+      bcDecimals: decimals.scDecimals,
+      amountForLimitFn: (amountScaled) => amountScaled,
+      isRatioOkFn: ({ totalScSupply, scPrice, reserveBc }) =>
+        isRatioAboveMin({ totalScSupply, scPrice, reserveBc }),
+      sellTx: sellScTx
     }
-    const getTradeData = async () => {
-      try {
-        const data = await tradeDataPriceBuySc(
-          djedContract,
-          decimals.scDecimals,
-          amountScaled
-        );
-
-        const futureSCPrice = await getFutureScPrice({
-          amountBC: data.totalUnscaled,
-          amountSC: data.amountUnscaled
-        });
-        const { f } = calculateTxFees(data.totalUnscaled, systemParams?.feeUnscaled, 0);
-        const isRatioAboveMinimum = isRatioAboveMin({
-          totalScSupply: BigNumber.from(coinsDetails?.unscaledNumberSc).add(
-            BigNumber.from(data.amountUnscaled)
-          ),
-          scPrice: BigNumber.from(futureSCPrice),
-          reserveBc: BigNumber.from(coinsDetails?.unscaledReserveBc).add(
-            BigNumber.from(data.totalUnscaled).add(f)
-          )
-        });
-
-        setTradeData(data);
-        if (!isWalletConnected) {
-          setBuyValidity(TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED);
-        } else if (isWrongChain) {
-          setBuyValidity(TRANSACTION_VALIDITY.WRONG_NETWORK);
-        } else if (
-          isTxLimitReached(
-            amountScaled,
-            coinsDetails.unscaledNumberSc,
-            systemParams.thresholdSupplySC
-          )
-        ) {
-          setBuyValidity(TRANSACTION_VALIDITY.TRANSACTION_LIMIT_REACHED);
-        } else if (
-          stringToBigNumber(accountDetails.unscaledBalanceBc, BC_DECIMALS).lt(
-            stringToBigNumber(data.totalBCUnscaled, BC_DECIMALS)
-          )
-        ) {
-          setBuyValidity(TRANSACTION_VALIDITY.INSUFFICIENT_BC);
-        } else if (!isRatioAboveMinimum) {
-          setBuyValidity(TRANSACTION_VALIDITY.RESERVE_RATIO_LOW);
-        } else {
-          checkBuyableSc(
-            djedContract,
-            data.amountUnscaled,
-            coinBudgets?.unscaledBudgetSc
-          ).then((res) => {
-            setBuyValidity(res);
-          });
-        }
-      } catch (error) {
-        console.log("error", error);
-      }
-    };
-    getTradeData();
-  };
-
-  const updateSellTradeData = (amountScaled) => {
-    const inputSanity = validatePositiveNumber(amountScaled);
-    if (inputSanity !== TRANSACTION_VALIDITY.OK) {
-      setSellValidity(inputSanity);
-      return;
-    }
-    const getTradeData = async () => {
-      try {
-        const data = await tradeDataPriceSellSc(
-          djedContract,
-          decimals.scDecimals,
-          amountScaled
-        );
-        setTradeData(data);
-        if (!isWalletConnected) {
-          setSellValidity(TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED);
-        } else if (isWrongChain) {
-          setSellValidity(TRANSACTION_VALIDITY.WRONG_NETWORK);
-        } else if (
-          isTxLimitReached(
-            amountScaled,
-            coinsDetails.unscaledNumberSc,
-            systemParams.thresholdSupplySC
-          )
-        ) {
-          setSellValidity(TRANSACTION_VALIDITY.TRANSACTION_LIMIT_REACHED);
-        } else if (
-          stringToBigNumber(accountDetails.unscaledBalanceSc, decimals.scDecimals).lt(
-            stringToBigNumber(data.amountUnscaled, decimals.scDecimals)
-          )
-        ) {
-          setSellValidity(TRANSACTION_VALIDITY.INSUFFICIENT_SC);
-        } else {
-          checkSellableSc(data.amountUnscaled, accountDetails?.unscaledBalanceSc).then(
-            (res) => setSellValidity(res)
-          );
-        }
-      } catch (error) {
-        console.log("error", error);
-      }
-    };
-    getTradeData();
-  };
-
-  const onChangeBuyInput = (amountScaled) => {
-    setValue(amountScaled);
-    updateBuyTradeData(amountScaled);
-  };
-  const onChangeSellInput = (amountScaled) => {
-    setValue(amountScaled);
-    updateSellTradeData(amountScaled);
-  };
-
-  const buySc = (total) => {
-    console.log("Attempting to buy SC for", total);
-    setTxStatus("pending");
-    promiseTx(isWalletConnected, buyScTx(djedContract, account, total), signer)
-      .then(({ hash }) => {
-        verifyTx(web3, hash).then((res) => {
-          if (res) {
-            console.log("Buy SC success!");
-            setTxStatus("success");
-          } else {
-            console.log("Buy SC reverted!");
-            setTxError("The transaction reverted.");
-            setTxStatus("rejected");
-          }
-        });
-      })
-      .catch((err) => {
-        console.error("Buy SC error:", err.message);
-        setTxStatus("rejected");
-        setTxError("MetaMask error. See developer console for details.");
-      });
-  };
-
-  const sellSc = (amount) => {
-    console.log("Attempting to sell SC in amount", amount);
-    setTxStatus("pending");
-    promiseTx(isWalletConnected, sellScTx(djedContract, account, amount), signer)
-      .then(({ hash }) => {
-        verifyTx(web3, hash).then((res) => {
-          if (res) {
-            console.log("Sell SC success!");
-            setTxStatus("success");
-          } else {
-            console.log("Sell SC reverted!");
-            setTxError("The transaction reverted.");
-            setTxStatus("rejected");
-          }
-        });
-      })
-      .catch((err) => {
-        console.error("Sell SC error:", err.message);
-        setTxStatus("rejected");
-        setTxError("MetaMask error. See developer console for details.");
-      });
-  };
-
-  const currentAmount = isBuyActive
-    ? tradeData.totalBCUnscaled
-    : tradeData.amountUnscaled;
-
-  const tradeFxn = isBuyActive
-    ? buySc.bind(null, tradeData.totalBCUnscaled)
-    : sellSc.bind(null, tradeData.amountUnscaled);
-
-  const onSubmit = (e) => {
-    if (!isWalletConnected) return;
-    if (!termsAccepted) return;
-    e.preventDefault();
-    if (isWSCConnected) {
-      setOpen(true);
-      return;
-    }
-    tradeFxn();
-  };
-
-  const transactionValidated = isBuyActive
-    ? buyValidity === TRANSACTION_VALIDITY.OK
-    : sellValidity === TRANSACTION_VALIDITY.OK;
-
-  const buttonDisabled =
-    isNaN(parseFloat(value)) ||
-    parseFloat(value) === 0 ||
-    isWrongChain ||
-    !transactionValidated;
+  });
 
   const scFloat = parseFloat(coinsDetails?.scaledNumberSc.replaceAll(",", ""));
   const scConverted = getScAdaEquivalent(coinsDetails, scFloat);
@@ -407,6 +227,12 @@ export default function Stablecoin() {
                       unwrapAmount={
                         isBuyActive ? tradeData.amountUnscaled : tradeData.totalBCUnscaled
                       }
+                      evmTokenAddress={process.env.REACT_APP_EVM_STABLECOIN_ADDRESS}
+                      cardanoWrapTokenUnit={process.env.REACT_APP_CARDANO_STABLECOIN_ADDRESS}
+                      buyFunctionName="buyStableCoins"
+                      sellFunctionName="sellStableCoins"
+                      titleBuy="Buy SC with WSC"
+                      titleSell="Sell SC with WSC"
                     />
                   ) : (
                     <BuySellButton
@@ -455,58 +281,4 @@ export default function Stablecoin() {
   );
 }
 
-const WSCButton = ({ disabled, currentAmount, unwrapAmount, stepTxDirection }) => {
-  const { address: account } = useAccount();
-
-  const buyOptions = {
-    defaultWrapToken: {
-      unit: "lovelace",
-      amount: currentAmount // amountUnscaled
-    },
-    defaultUnwrapToken: {
-      unit: process.env.REACT_APP_EVM_STABLECOIN_ADDRESS,
-      amount: unwrapAmount // amountUnscaled
-    },
-    titleModal: "Buy SC with WSC",
-    evmTokenAddress: process.env.REACT_APP_EVM_STABLECOIN_ADDRESS,
-    evmContractRequest: {
-      address: DJED_ADDRESS,
-      abi: djedArtifact.abi,
-      functionName: "buyStableCoins", //account, FEE_UI_UNSCALED, UI
-      args: [account, FEE_UI_UNSCALED, UI],
-      overrides: {
-        value: ethers.BigNumber.from(currentAmount ?? "0")
-      }
-    }
-  };
-
-  const sellOptions = {
-    defaultWrapToken: {
-      unit: process.env.REACT_APP_CARDANO_STABLECOIN_ADDRESS,
-      amount: currentAmount
-    },
-    defaultUnwrapToken: {
-      unit: "",
-      amount: unwrapAmount // totalBCUnscaled
-    },
-    titleModal: "Sell SC with WSC",
-    evmTokenAddress: process.env.REACT_APP_EVM_STABLECOIN_ADDRESS,
-    evmContractRequest: {
-      address: DJED_ADDRESS,
-      abi: djedArtifact.abi,
-      functionName: "sellStableCoins", //amount, account, FEE_UI_UNSCALED, UI
-      args: [currentAmount, account, FEE_UI_UNSCALED, UI],
-      overrides: {
-        value: ethers.BigNumber.from("0")
-      }
-    }
-  };
-
-  return (
-    <TransactionConfigWSCProvider
-      options={stepTxDirection === "buy" ? buyOptions : sellOptions}
-    >
-      <ConnectWSCButton disabled={disabled} />
-    </TransactionConfigWSCProvider>
-  );
-};
+// WSC button is now provided by src/routes/CoinWSCButton

--- a/src/routes/useCoinTrade.js
+++ b/src/routes/useCoinTrade.js
@@ -1,0 +1,193 @@
+import { useState } from "react";
+import { useAppProvider } from "../context/AppProvider";
+import useBuyOrSell from "../utils/hooks/useBuyOrSell";
+import { createBuyHandler, createSellHandler } from "./coinTradeHelpers";
+import { TRANSACTION_VALIDITY } from "../utils/constants";
+import { promiseTx, verifyTx, calculateTxFees, isTxLimitReached } from "../utils/ethereum";
+import { stringToBigNumber, validatePositiveNumber } from "../utils/helpers";
+import { BigNumber } from "ethers";
+import { useWSCProvider, useModal as useWSCModal } from "milkomeda-wsc-ui-test-beta";
+
+export default function useCoinTrade({
+  createBuyOptions = {},
+  createSellOptions = {}
+}) {
+  const {
+    web3,
+    isWalletConnected,
+    isWrongChain,
+    djedContract,
+    coinsDetails,
+    decimals,
+    accountDetails,
+    coinBudgets,
+    account,
+    signer,
+    systemParams,
+    getFutureScPrice
+  } = useAppProvider();
+  const { isWSCConnected } = useWSCProvider();
+  const { setOpen } = useWSCModal();
+  const { buyOrSell, isBuyActive, setBuyOrSell } = useBuyOrSell();
+
+  const [tradeData, setTradeData] = useState({});
+  const [value, setValue] = useState(null);
+  const [termsAccepted, setTermsAccepted] = useState(false);
+  const [txError, setTxError] = useState(null);
+  const [txStatus, setTxStatus] = useState("idle");
+  const [buyValidity, setBuyValidity] = useState(
+    TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED
+  );
+  const [sellValidity, setSellValidity] = useState(
+    TRANSACTION_VALIDITY.WALLET_NOT_CONNECTED
+  );
+
+  const txStatusPending = txStatus === "pending";
+  const txStatusRejected = txStatus === "rejected";
+  const txStatusSuccess = txStatus === "success";
+
+  const updateBuyTradeData = createBuyHandler({
+    validatePositiveNumber,
+    tradeDataPriceBuy: createBuyOptions.tradeDataPriceBuy,
+    djedContract,
+    decimalsValue: createBuyOptions.decimalsValue,
+    getFutureScPrice,
+    calculateTxFees,
+    systemParams,
+    isWalletConnected,
+    isWrongChain,
+    coinsDetails,
+    accountDetails,
+    isTxLimitReached,
+    checkBuyable: createBuyOptions.checkBuyable,
+    stringToBigNumber,
+    BC_DECIMALS: createBuyOptions.bcDecimals,
+    setTradeData,
+    setBuyValidity,
+    amountForLimitFn: createBuyOptions.amountForLimitFn,
+    isRatioOkFn: createBuyOptions.isRatioOkFn,
+    ratioFailState: createBuyOptions.ratioFailState,
+    budgetUnscaled: createBuyOptions.budgetUnscaled
+  });
+
+  const updateSellTradeData = createSellHandler({
+    validatePositiveNumber,
+    tradeDataPriceSell: createSellOptions.tradeDataPriceSell,
+    djedContract,
+    decimalsValue: createSellOptions.decimalsValue,
+    getFutureScPrice,
+    calculateTxFees,
+    systemParams,
+    isWalletConnected,
+    isWrongChain,
+    coinsDetails,
+    accountDetails,
+    isTxLimitReached,
+    checkSellable: createSellOptions.checkSellable,
+    stringToBigNumber,
+    bcDecimals: createSellOptions.bcDecimals,
+    setTradeData,
+    setSellValidity,
+    amountForLimitFn: createSellOptions.amountForLimitFn,
+    isRatioOkFn: createSellOptions.isRatioOkFn,
+    ratioFailState: createSellOptions.ratioFailState
+  });
+
+  const onChangeBuyInput = (amountScaled) => {
+    setValue(amountScaled);
+    updateBuyTradeData(amountScaled);
+  };
+  const onChangeSellInput = (amountScaled) => {
+    setValue(amountScaled);
+    updateSellTradeData(amountScaled);
+  };
+
+  const runTransaction = (txCreator) => {
+    return (amount) => {
+      setTxStatus("pending");
+      promiseTx(isWalletConnected, txCreator(djedContract, account, amount), signer)
+        .then(({ hash }) => {
+          verifyTx(web3, hash).then((res) => {
+            if (res) {
+              setTxStatus("success");
+            } else {
+              setTxError("The transaction reverted.");
+              setTxStatus("rejected");
+            }
+          });
+        })
+        .catch((err) => {
+          console.error("Error:", err.message);
+          setTxStatus("rejected");
+          setTxError("MetaMask error. See developer console for details.");
+        });
+    };
+  };
+
+  const buyFunction = createBuyOptions.buyTx
+    ? runTransaction(createBuyOptions.buyTx)
+    : null;
+  const sellFunction = createSellOptions.sellTx
+    ? runTransaction(createSellOptions.sellTx)
+    : null;
+
+  const tradeFxn = isBuyActive
+    ? buyFunction?.bind(null, tradeData.totalBCUnscaled)
+    : sellFunction?.bind(null, tradeData.amountUnscaled);
+
+  const currentAmount = isBuyActive
+    ? tradeData.totalBCUnscaled
+    : tradeData.amountUnscaled;
+
+  const onSubmit = (e) => {
+    if (!isWalletConnected) return;
+    if (!termsAccepted) return;
+    e.preventDefault();
+    if (isWSCConnected) {
+      setOpen(true);
+      return;
+    }
+    tradeFxn && tradeFxn();
+  };
+
+  const transactionValidated = isBuyActive
+    ? buyValidity === TRANSACTION_VALIDITY.OK
+    : sellValidity === TRANSACTION_VALIDITY.OK;
+
+  const buttonDisabled =
+    isNaN(parseFloat(value)) ||
+    parseFloat(value) === 0 ||
+    isWrongChain ||
+    !transactionValidated;
+
+  return {
+    tradeData,
+    value,
+    termsAccepted,
+    txError,
+    txStatus,
+    buyValidity,
+    sellValidity,
+    txStatusPending,
+    txStatusRejected,
+    txStatusSuccess,
+    buyFunction,
+    sellFunction,
+    tradeFxn,
+    currentAmount,
+    onChangeBuyInput,
+    onChangeSellInput,
+    onSubmit,
+    transactionValidated,
+    buttonDisabled,
+    setValue,
+    setTermsAccepted,
+    setBuyOrSell,
+    setBuyValidity,
+    setSellValidity,
+    buyOrSell,
+    isBuyActive
+    ,
+    isWSCConnected
+  };
+}

--- a/tests/playwright/nav.spec.js
+++ b/tests/playwright/nav.spec.js
@@ -1,0 +1,14 @@
+const { test, expect } = require('@playwright/test');
+
+test('navigate to StableCoin and ReserveCoin via main nav', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('nav, header')).toBeVisible();
+
+  // Click the StableCoin link in the main nav
+  await page.click('text=StableCoin');
+  await expect(page.locator('h1')).toContainText('StableCoin');
+
+  // Click the ReserveCoin link
+  await page.click('text=ReserveCoin');
+  await expect(page.locator('h1')).toContainText('ReserveCoin');
+});


### PR DESCRIPTION
This PR removes duplicated trade handling and transaction logic from
src/routes/stablecoin.jsx and src/routes/reservecoin.jsx by introducing a shared hook:
src/routes/useCoinTrade.js.

🔧 Changes

Added src/routes/useCoinTrade.js, a reusable hook that encapsulates:

Trade state management

Input validation

Trade data updates

Buy/Sell transaction execution logic

Refactored stablecoin.jsx and reservecoin.jsx to use the shared hook with coin-specific configuration.

Removed duplicated createBuyHandler / createSellHandler logic and route-specific transaction runners.

📌 Notes

UI behavior and WSC button usage remain unchanged.

Route-specific options are passed into the shared hook to preserve existing functionality.

Some unit tests in the project are currently failing, but these failures are unrelated to this refactor and were not introduced by this PR.